### PR TITLE
Use gatsby:latest instead of onbuild to copy current folder

### DIFF
--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,1 +1,3 @@
-FROM gatsbyjs/gatsby:onbuild
+FROM gatsbyjs/gatsby:latest
+
+ADD . /pub


### PR DESCRIPTION
Fixing new docker deployment