### PR TITLE
Fixed open links in a new tab

### DIFF
--- a/scripts/src/components/header/index.js
+++ b/scripts/src/components/header/index.js
@@ -8,8 +8,8 @@ const links = [
   { url: '/publications/', text: 'Publications' },
   { url: '/awards/', text: 'Awards' },
 
-  { url: '/students/', text: 'For students' },
-  { url: '/collaborators/', text: 'For collaborators' },
+  { url: '/students/teaching/', text: 'For students' },
+  { url: '/collaborators/activeprojects/', text: 'For collaborators' },
 
   { url: '/team/', text: 'Team' },
   { url: '/jobs', text: 'Vacancies' },


### PR DESCRIPTION
Links "For students" and "For collaborators" didn't open in new tabs. When I tried to open it, status "403 Forbidden" returned.