### PR TITLE
Fix issue with bibtex hover in publications

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dice-website",
-  "version": "0.1.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/scripts/postcss.config.js
+++ b/scripts/postcss.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   plugins: {
-    'postcss-nested': {},
     tailwindcss: {},
+    'postcss-nested': {},
     autoprefixer: {},
   },
 };

--- a/scripts/src/components/styles/main.css
+++ b/scripts/src/components/styles/main.css
@@ -812,11 +812,14 @@ a {
     @apply hidden ml-1 text-base;
     color: var(--primary-color);
   }
+
+  /*! purgecss start ignore */
   &:hover {
     .bib-link {
       @apply inline;
     }
   }
+  /*! purgecss end ignore */
 }
 
 /*


### PR DESCRIPTION
"Get bibtex" on-hover was getting removed by postcss purge for some reason during production build (a bug?). 
This forces to ignore it and always keep it in final build.