### PR TITLE
Fix ontolearn typo

### DIFF
--- a/data/people/CaglarDemir.ttl
+++ b/data/people/CaglarDemir.ttl
@@ -25,7 +25,7 @@ For more, please refer to
 ## Software Frameworks
 
 * <a href="https://github.com/dice-group/dice-embeddings">DICE Embeddings: Hardware-agnostic Framework for Large-scale Knowledge Graph Embeddings</a>
-* <a href="https://github.com/dice-group/Ontolearns">Ontolearn: Scalable Description Logic Concept Learning Framework</a>
+* <a href="https://github.com/dice-group/Ontolearn">Ontolearn: Scalable Description Logic Concept Learning Framework</a>
 
 
 ## PC Member

--- a/data/people/JNKouagou.ttl
+++ b/data/people/JNKouagou.ttl
@@ -23,6 +23,6 @@ For more, please refer to
 
 ## Software Frameworks
 
-* <a href="https://github.com/dice-group/Ontolearns">Ontolearn: Scalable Description Logic Concept Learning Framework</a>
+* <a href="https://github.com/dice-group/Ontolearn">Ontolearn: Scalable Description Logic Concept Learning Framework</a>
   """ .
 


### PR DESCRIPTION
The links to Ontolearn's repository on my profile and Demir's were wrong, point to a non-existent page. It has now been fixed. Please merge when possible.